### PR TITLE
Handler Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN ?= bin/ws-example
-GOMOD_MODE ?= vendor
+GO_MOD_MODE ?= vendor
 GOLANG_CI_LINT_VERSION ?= v1.31
 
 .PHONY: all

--- a/internal/handlers/ws.go
+++ b/internal/handlers/ws.go
@@ -19,30 +19,37 @@ func (handler *WebSocketHandler) ServeHTTP(w http.ResponseWriter, req *http.Requ
 	conn, err := handler.Upgrader.Upgrade(w, req, nil)
 	if err != nil {
 		handler.Logger.Println("Error upgrading connection:", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer func() {
+		// ensure connection is closed by forcibly closing it
+		if err := conn.Close(); err != nil {
+			handler.Logger.Println("Error closing connection:", err)
+		}
+	}()
 
 	err = conn.WriteMessage(websocket.TextMessage,
 		[]byte(fmt.Sprintf("[%s] hello :) type a message and press ENTER", handler.ID)),
 	)
 
 	if err != nil {
-		log.Println(err)
+		handler.Logger.Println("Error writing greeting to socket:", err)
 		// continue on regardless of error
 	}
 
 	for {
 		messageType, p, err := conn.ReadMessage()
 		if err != nil {
-			log.Println(err)
+			handler.Logger.Println("Error reading message:", err)
 			return
 		}
-		fmt.Println("Got message:", strings.Trim(string(p), "\n"))
+		handler.Logger.Println("Got message:", strings.Trim(string(p), "\n"))
 		err = conn.WriteMessage(messageType,
 			append([]byte(fmt.Sprintf("[%s] ", handler.ID)), p...),
 		)
 		if err != nil {
-			log.Println(err)
+			handler.Logger.Println("Error writing message to socket:", err)
 			return
 		}
 	}


### PR DESCRIPTION
Take a pass at cleaning up the websocket handler. 

- Close the websocket connection once it's no longer in use
- Return a status code to the client if we fail to upgrade the connection
- Use proper logging instead of `fmt` and `log`